### PR TITLE
Add support for timestamp column statistics in Hive metastore v4

### DIFF
--- a/src/main/thrift/hive_metastore.thrift
+++ b/src/main/thrift/hive_metastore.thrift
@@ -529,6 +529,18 @@ struct DateColumnStatsData {
 5: optional binary bitVectors
 }
 
+struct Timestamp {
+1: required i64 secondsSinceEpoch
+}
+
+struct TimestampColumnStatsData {
+1: optional Timestamp lowValue,
+2: optional Timestamp highValue,
+3: required i64 numNulls,
+4: required i64 numDVs,
+5: optional binary bitVectors
+}
+
 union ColumnStatisticsData {
 1: BooleanColumnStatsData booleanStats,
 2: LongColumnStatsData longStats,
@@ -536,7 +548,8 @@ union ColumnStatisticsData {
 4: StringColumnStatsData stringStats,
 5: BinaryColumnStatsData binaryStats,
 6: DecimalColumnStatsData decimalStats,
-7: DateColumnStatsData dateStats
+7: DateColumnStatsData dateStats,
+8: TimestampColumnStatsData timestampStats
 }
 
 struct ColumnStatisticsObj {


### PR DESCRIPTION
Add handling of TimestampColumnStatsData to support timestamp column statistics in Hive metastore v3 and v4.
After merging I will fix this [pull request](https://github.com/trinodb/trino/pull/26338) that will fix the [bug](https://github.com/trinodb/trino/issues/26214)